### PR TITLE
Asset's sourcePath alias fix

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -16,7 +16,7 @@ class Asset extends AssetBundle
 	/**
 	 * @inheritdoc
 	 */
-	public $sourcePath = '@vova07/imperavi/assets';
+	public $sourcePath = '@vendor/vova07/yii2-imperavi-widget/src/assets';
 
 	/**
 	 * @var string Redactor language


### PR DESCRIPTION
because `@vova07/imperavi` alias is not been set in the widget
