### PR TITLE
change access level

### DIFF
--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -163,7 +163,7 @@ class FileHelper extends BaseFileHelper
      *
      * @codeCoverageIgnore
      */
-    private static function normalizeOptions(array $options)
+    protected static function normalizeOptions(array $options)
     {
         if (!array_key_exists('caseSensitive', $options)) {
             $options['caseSensitive'] = true;


### PR DESCRIPTION
private level lead to "[error][yii\base\ErrorException:64] yii\base\ErrorException: Access level to vova07\imperavi\helpers\FileHelper::normalizeOptions() must be protected (as in class yii\helpers\BaseFileHelper) or weaker in  var/www/admin/www/glowder.com/Syren/vendor/vova07/yii2-imperavi-widget/src/helpers/FileHelper.php:17"