### PR TITLE
Removed FileHelper::normalizeOptions() to use parent implementaion

### DIFF
--- a/src/helpers/FileHelper.php
+++ b/src/helpers/FileHelper.php
@@ -37,7 +37,7 @@ class FileHelper extends BaseFileHelper
         if (!isset($options['basePath'])) {
             $options['basePath'] = realpath($dir);
             // this should also be done only once
-            $options = self::normalizeOptions($options);
+            $options = static::normalizeOptions($options);
         }
         $list = [];
         $handle = opendir($dir);
@@ -156,32 +156,5 @@ class FileHelper extends BaseFileHelper
         };
 
         return array_reduce($wildcards, $wildcardSearch, false);
-    }
-
-    /**
-     * @inheritdoc
-     *
-     * @codeCoverageIgnore
-     */
-    private static function normalizeOptions(array $options)
-    {
-        if (!array_key_exists('caseSensitive', $options)) {
-            $options['caseSensitive'] = true;
-        }
-        if (isset($options['except'])) {
-            foreach ($options['except'] as $key => $value) {
-                if (is_string($value)) {
-                    $options['except'][$key] = self::parseExcludePattern($value, $options['caseSensitive']);
-                }
-            }
-        }
-        if (isset($options['only'])) {
-            foreach ($options['only'] as $key => $value) {
-                if (is_string($value)) {
-                    $options['only'][$key] = self::parseExcludePattern($value, $options['caseSensitive']);
-                }
-            }
-        }
-        return $options;
     }
 }


### PR DESCRIPTION
Since Yii 2.0.12, `BaseFileHelper::normalizeOptions()` is a protected method.
https://github.com/yiisoft/yii2/commit/debe85fa347ccccec741c4d7ec50fa8e251a85b9

This change fixes your implementation of FileHelper to work with newer API of parent class.

Closes #91 
Closes #92 
Closes #90