### PR TITLE
Fix redactor issue on Chrome 58

### DIFF
--- a/src/assets/redactor.js
+++ b/src/assets/redactor.js
@@ -7728,6 +7728,12 @@
 					{
 						var node2 = this.selection.getMarker(2);
 						this.selection.setMarker(this.range, node2, false);
+						// concrete5 start - https://github.com/concrete5/concrete5/issues/5406
+						if (this.utils.browser('chrome'))
+						{
+						    this.caret.set(node1, 0, node2, 0);
+						}
+						// concrete5 end
 					}
 
 					this.savedSel = this.$editor.html();


### PR DESCRIPTION
fix by https://github.com/concrete5/concrete5/pull/5425/commits/3482125462871f6a1a39adcdc9bdde656bfae017

Chrome Version 59.0.3071.115 (Official Build) (64-bit)

Issue:

- Add a content Block to the page
- Add text into the redactor
- Select some text
- add bold style to the selected text

Results:

- The related markup was not added
- after clicking abort on the redactor panel, the corresponding area can not be selected anymore